### PR TITLE
Pull up last search when returning to app

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -51,6 +51,7 @@
     </svg>
   </div>
 
+  <script src="scripts/audioManager.js" async></script>
   <script src="scripts/app.js" async></script>
 
 </body>

--- a/website/index.html
+++ b/website/index.html
@@ -23,7 +23,7 @@
 
   <header class="header">
     <!-- lol, todo -->
-    <h1 class="header__title" onclick="
+    <h1 class="header-title" onclick="
       document.querySelector('#search-input').style.display == 'block'
         ? document.querySelector('#search-input').style.display = 'none'
         : document.querySelector('#search-input').style.display = 'block'">

--- a/website/scripts/app.js
+++ b/website/scripts/app.js
@@ -11,45 +11,6 @@
     container: document.querySelector('.main')
   };
 
-  app.playbackStateTracker = {
-    get: function() {
-      return JSON.parse(localStorage.getItem("playbackState"));
-    },
-    runner: function() {
-      localStorage.setItem("playbackState", JSON.stringify({
-        currentSrc: mainAudio.currentSrc,
-        currentTime: mainAudio.currentTime
-      }));
-    },
-    handle: null,
-    start: function() {
-      // Could use onTimeUpdate on the video player, but this should be
-      // less of a hit on performance.
-      app.playbackStateTracker.handle = setInterval(app.playbackStateTracker.runner, 5000);
-    },
-    stop: function() {
-      if (app.playbackStateTracker.handle) {
-        clearInterval(app.playbackStateTracker.handle);
-      }
-    }
-  };
-
-  app.resumePlayback = function() {
-    if (mainAudio.paused) {
-      const playbackState = app.playbackStateTracker.get();
-      var source = document.getElementById('audioSource');
-      source.src = playbackState.currentSrc;
-      mainAudio.load();
-      mainAudio.currentTime = playbackState.currentTime;
-      mainAudio.play();
-      app.playbackStateTracker.start();
-    }
-  }
-
-  mainAudio.onPause = function() {
-    app.playbackStateTracker.stop();
-  };
-
   app.updateSearchCard = function(data, searchTerm) {
     var card = document;
     if(!searchTerm) {
@@ -73,12 +34,7 @@
     episodes.forEach(function(e) {
       var li = document.createElement('li');
       li.onclick = function () {
-        var source = document.getElementById('audioSource');
-        source.src = e.audioUrl;
-        mainAudio.pause();
-        mainAudio.load();
-        mainAudio.play();
-        app.playbackStateTracker.start();
+        AudioManager.play(e.audioUrl)
       };
 
       li.audioUrl = e.audioUrl;
@@ -132,7 +88,6 @@
   if (location.search) {
       var searchTerm = location.search.split('=')[1]; // TODO robust!
       app.search(searchTerm);
-      app.resumePlayback();
   } else {
     // First load
     app.updateSearchCard({});

--- a/website/scripts/app.js
+++ b/website/scripts/app.js
@@ -1,8 +1,9 @@
 (function() {
   'use strict';
 
-  var baseUrl = 'https://podcasts.search.windows.net/indexes/podcasts/docs?api-version=2017-11-11&$count=true&search=';
-  var apiKey = 'C7AC76C4D8E4FE369B5608D13A98468F'; // TODO!!
+  const searchTermStorageKey = "searchTerm";
+  const baseUrl = 'https://podcasts.search.windows.net/indexes/podcasts/docs?api-version=2017-11-11&$count=true&search=';
+  const apiKey = 'C7AC76C4D8E4FE369B5608D13A98468F'; // TODO!!
 
   var app = {
     isLoading: true,
@@ -10,6 +11,7 @@
     spinner: document.querySelector('.loader'),
     container: document.querySelector('.main')
   };
+
 
   app.updateSearchCard = function(data, searchTerm) {
     var card = document;
@@ -55,7 +57,12 @@
     }
   };
 
+  app.saveSearchState = function(searchTerm) {
+    localStorage.setItem(searchTermStorageKey, searchTerm);
+  };
+
   app.search = function(searchTerm) {
+    app.saveSearchState(searchTerm);
     var url = baseUrl + searchTerm;
     if ('caches' in window) {
       caches.match(url).then(function(response) {
@@ -90,7 +97,12 @@
       app.search(searchTerm);
   } else {
     // First load
-    app.updateSearchCard({});
+    const searchTerm = localStorage.getItem(searchTermStorageKey);
+    if (searchTerm) {
+      app.search(searchTerm)
+    } else {
+      app.updateSearchCard({});
+    }
   }
 
   if ('serviceWorker' in navigator) {

--- a/website/scripts/audioManager.js
+++ b/website/scripts/audioManager.js
@@ -12,7 +12,7 @@ var AudioManager = {
     },
     handle: null,
     start: function() {
-      // Could use onTimeUpdate on the video player, but this should be
+      // Could use onTimeUpdate on the audio player, but this should be
       // less of a hit on performance.
       AudioManager.playbackStateTracker.saveState(); // Initial save without delay
       AudioManager.playbackStateTracker.handle = setInterval(AudioManager.playbackStateTracker.saveState, 5000);

--- a/website/scripts/audioManager.js
+++ b/website/scripts/audioManager.js
@@ -1,0 +1,65 @@
+var AudioManager = {
+
+  playbackStateTracker: {
+    get: function() {
+      return JSON.parse(localStorage.getItem("playbackState"));
+    },
+    saveState: function() {
+      localStorage.setItem("playbackState", JSON.stringify({
+        currentSrc: mainAudio.currentSrc,
+        currentTime: mainAudio.currentTime
+      }));
+    },
+    handle: null,
+    start: function() {
+      // Could use onTimeUpdate on the video player, but this should be
+      // less of a hit on performance.
+      AudioManager.playbackStateTracker.saveState(); // Initial save without delay
+      AudioManager.playbackStateTracker.handle = setInterval(AudioManager.playbackStateTracker.saveState, 5000);
+    },
+    stop: function() {
+      if (AudioManager.playbackStateTracker.handle) {
+        clearInterval(AudioManager.playbackStateTracker.handle);
+      }
+      AudioManager.playbackStateTracker.saveState(); // One last save
+    }
+  },
+  load: function(src, currentTime) {
+    var source = document.getElementById('audioSource');
+    source.src = src;
+    mainAudio.load();
+    if (currentTime) {
+      mainAudio.currentTime = currentTime
+    }
+  },
+  play: function(src, currentTime) {
+    AudioManager.load(src, currentTime);
+    mainAudio.play();
+    AudioManager.playbackStateTracker.start();
+  },
+  pause: function() {
+    if (!mainAudio.paused) {
+      mainAudio.pause();
+    }
+    AudioManager.playbackStateTracker.stop();
+  },
+  resume: function() {
+    if (mainAudio.paused) {
+      const playbackState = AudioManager.playbackStateTracker.get();
+      if (playbackState === null) {
+        return;
+      }
+      AudioManager.load(playbackState.currentSrc, playbackState.currentTime);
+    }
+  }
+};
+
+mainAudio.onpause = function() {
+  AudioManager.pause();
+};
+
+mainAudio.onplay = function() {
+  AudioManager.playbackStateTracker.start();
+};
+
+AudioManager.resume();

--- a/website/styles/inline.css
+++ b/website/styles/inline.css
@@ -97,7 +97,7 @@ body {
 .header #butRefresh {
   background: url(/images/ic_refresh_white_24px.svg) center center no-repeat;
 }
-.header__title {
+.header-title {
   font-weight: 400;
   font-size: 20px;
   margin: 0;


### PR DESCRIPTION
For #11 - pull up last search when returning to app.
Also some refactoring of audio playback.

This change doesn't replace the URL, i.e. it will just be the base URL without the `?s=searchTerm`, since there doesn't seem to be a simple way to do that without reloading the page or breaking back/forwards functionality.

If you want to change the URL to reflect the searched term, I'd suggest adding [history.js](https://github.com/browserstate/history.js)