### PR TITLE
Additional cases for JavaScript Jabber title cleansing

### DIFF
--- a/podcast-feed-loader/app/data/feeds.json
+++ b/podcast-feed-loader/app/data/feeds.json
@@ -91,7 +91,7 @@
       "title": null
     },
     {
-      "titleCleanser": "^JSJ\\s\\d+:\\s",
+      "titleCleanser": "^(?:(?:JSJ\\s|\\d+(?:\\s|:))){2}\\s?",
       "url": "https://feeds.feedwrench.com/js-jabber.rss",
       "title": null
     },


### PR DESCRIPTION
Realized I missed a few cases since their versioning scheme has changed over time. Updated RegExp covers the following scenarios:

```
JSJ 309: WebAssembly and JavaScript with Ben Titzer
JSJ 267 Node 8 with Mikeal Rogers, Arunesh Chandra, and Anna Henningsen
231 JSJ Codewars with Nathan Doctor, Jake Hoffner, and Dan Nolan
```