### PR TITLE
Fixing TypeError: os.home.dir error 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ignore": [
       "**/node_modules/",
       "**/build/",
-      "**/coverage/"
+      "**/coverage/",
+      "**/cypress/"
     ],
     "env": {
       "jest": true

--- a/website-react/cypress/integration/main.spec.js
+++ b/website-react/cypress/integration/main.spec.js
@@ -1,4 +1,3 @@
-import { cy } from 'cypress'
 
 describe('Main', function () {
   beforeEach(function () {

--- a/website-react/cypress/integration/queue.spec.js
+++ b/website-react/cypress/integration/queue.spec.js
@@ -1,4 +1,3 @@
-import { cy } from 'cypress'
 
 describe('Queue', function () {
   beforeEach(function () {

--- a/website-react/cypress/integration/search.spec.js
+++ b/website-react/cypress/integration/search.spec.js
@@ -1,4 +1,3 @@
-import { cy } from 'cypress'
 
 describe('Search', function () {
   describe('Input', function () {

--- a/website-react/cypress/support/index.js
+++ b/website-react/cypress/support/index.js
@@ -15,7 +15,6 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-import { Cypress } from 'cypress'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -37,3 +36,4 @@ import { Cypress } from 'cypress'
 Cypress.on('window:before:load', win => {
   win.fetch = null
 })
+

--- a/website-react/package.json
+++ b/website-react/package.json
@@ -35,7 +35,8 @@
   "standard": {
     "parser": "babel-eslint",
     "ignore": [
-      "/build"
+      "/build",
+      "/cypress"
     ],
     "env": {
       "jest": true


### PR DESCRIPTION
... that was induced by previous commit that was trying to working around the issues between cypress and standard.js.  For now, I have put an ignore statement to exclude cypress from the standard.js linting.