### PR TITLE
Added an all-in-one test command: 'npm run ci'  

### DIFF
--- a/website-react/package.json
+++ b/website-react/package.json
@@ -21,6 +21,7 @@
     "testNonInteractive": "react-scripts test --env=jsdom --coverage",
     "cypress:open": "cypress open",
     "e2e": "cypress run",
+    "ci": "start-server-and-test start http://localhost:3000 e2e",
     "lint": "standard --fix"
   },
   "devDependencies": {
@@ -30,7 +31,8 @@
     "jest": "^23.1.0",
     "react-test-renderer": "^16.4.1",
     "sinon": "^6.0.0",
-    "standard": "^11.0.1"
+    "standard": "^11.0.1",
+    "start-server-and-test": "^1.4.1"
   },
   "standard": {
     "parser": "babel-eslint",


### PR DESCRIPTION
The requires running the following command in the webapp:

```npm install```

This closes #131.