### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[{package.json,*.yml,*.cjson}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This editorconfig file matches the standard linting rules as far as I can tell. Taken from here: https://github.com/gustavnikolaj/linter-js-standard-engine/blob/master/.editorconfig