### PR TITLE
Potential fix for input searching e2e tests

### DIFF
--- a/website-react/cypress/integration/search.spec.js
+++ b/website-react/cypress/integration/search.spec.js
@@ -23,11 +23,11 @@ describe('Search', function () {
       cy.get('form').submit()
     })
 
-    it.skip('returns the correct results length', function () {
+    it('returns the correct results length', function () {
       cy.get('[data-item-type=search]').should('have.length', this.lambda_search_results['@odata.count'])
     })
 
-    it.skip('returns empty results', function (done) {
+    it('returns empty results', function () {
       cy.route({
         method: 'GET',
         url: Cypress.env('baseSearchUrl').replace('{searchTerm}', 'empty'),
@@ -38,18 +38,15 @@ describe('Search', function () {
       // running with electron in headless mode. Issue #127
       cy.visit('/')
 
-      setTimeout(() => {
-        cy.get('input')
-          .clear()
-          .type('empty')
-          .should('have.value', 'empty')
+      cy.get('input')
+        .clear()
+        .type('empty')
+        .should('have.value', 'empty')
 
-        cy.get('form').submit()
+      cy.get('form').submit()
 
-        cy.get('#resultText').contains('0 results for "empty"')
-        cy.get('#noResults').contains('No results were found. Please try again.')
-        done()
-      }, 2000)
+      cy.get('#resultText').contains('0 results for "empty"')
+      cy.get('#noResults').contains('No results were found. Please try again.')
     })
 
     it('can load the main page via back button', function () {
@@ -65,7 +62,7 @@ describe('Search', function () {
     })
   })
 
-  describe('Direct', function () {
+  describe('URL', function () {
     beforeEach(function () {
       cy.server()
 

--- a/website-react/cypress/support/index.js
+++ b/website-react/cypress/support/index.js
@@ -35,28 +35,28 @@ import './commands'
 // Reference: https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
 Cypress.on('window:before:load', win => {
   win.fetch = null
-  
+
   const unregisterSW = () => {
     return navigator.serviceWorker.getRegistrations()
-    .then((registrations) => {
-      const unregisterPromise = registrations.map((registration) => {
-        return registration.unregister();
-      });
-      return Promise.all(unregisterPromise);
-    });
-  };
+      .then((registrations) => {
+        const unregisterPromise = registrations.map((registration) => {
+          return registration.unregister()
+        })
+        return Promise.all(unregisterPromise)
+      })
+  }
 
   const clearCaches = () => {
     return window.caches.keys()
-    .then((cacheNames) => {
-      return Promise.all(cacheNames.map((cacheName) => {
-        return window.caches.delete(cacheName);
-      }));
-    });
-  };
+      .then((cacheNames) => {
+        return Promise.all(cacheNames.map((cacheName) => {
+          return window.caches.delete(cacheName)
+        }))
+      })
+  }
 
   return Promise.all([
     unregisterSW(),
-    clearCaches(),
-  ]);
+    clearCaches()
+  ])
 })

--- a/website-react/cypress/support/index.js
+++ b/website-react/cypress/support/index.js
@@ -35,4 +35,28 @@ import './commands'
 // Reference: https://github.com/cypress-io/cypress/issues/95#issuecomment-347607198
 Cypress.on('window:before:load', win => {
   win.fetch = null
+  
+  const unregisterSW = () => {
+    return navigator.serviceWorker.getRegistrations()
+    .then((registrations) => {
+      const unregisterPromise = registrations.map((registration) => {
+        return registration.unregister();
+      });
+      return Promise.all(unregisterPromise);
+    });
+  };
+
+  const clearCaches = () => {
+    return window.caches.keys()
+    .then((cacheNames) => {
+      return Promise.all(cacheNames.map((cacheName) => {
+        return window.caches.delete(cacheName);
+      }));
+    });
+  };
+
+  return Promise.all([
+    unregisterSW(),
+    clearCaches(),
+  ]);
 })


### PR DESCRIPTION
Added clearning of cache and unregistering service workers on the window before load event.  This _seems_ to _maybe_ have _fixed_ the intermittant errors with the input searching e2e tests.

It has passed 10 times in a row on Travis CI.