### PR TITLE
Show actual result count

### DIFF
--- a/website-react/src/components/Main/SearchResults.js
+++ b/website-react/src/components/Main/SearchResults.js
@@ -24,6 +24,7 @@ export class SearchResults extends Component {
     const {
       className,
       results,
+      resultCount,
       queue,
       nowPlaying,
       currentSearch,
@@ -45,11 +46,11 @@ export class SearchResults extends Component {
       >
         <div id='searchContainer'>
           <div id='resultText'>
-            {results.length === maxResults ? (
-              `More than ${maxResults} results found for "${currentSearch}".
-                  Showing the first ${maxResults}.`
+            {resultCount >= maxResults ? (
+              `${resultCount} results found for "${currentSearch}".
+                  Showing the first ${maxResults} results.`
             ) : (
-              `${results.length} results for "${currentSearch}"`
+              `${resultCount} results for "${currentSearch}"`
             )
             }
           </div>
@@ -100,6 +101,7 @@ SearchResults.defaultProps = {
 export const ConnectedSearchResults = connect(state => ({
   nowPlaying: state.player.nowPlaying,
   results: state.search.results,
+  resultCount: state.search.resultCount,
   queue: state.player.queue,
   currentSearch: state.search.currentSearch,
   maxResults: state.search.maxResults,

--- a/website-react/src/models/SearchModel.js
+++ b/website-react/src/models/SearchModel.js
@@ -8,19 +8,21 @@ export default mirror.model({
     maxResults: config.maxResults,
     currentSearch: '',
     results: [],
+    resultCount: null,
     loading: false
   },
   reducers: {
     updateSearchTerm (state, searchTerm) {
       return {...state, searchTerm}
     },
-    updateResults (state, results) {
+    updateResults (state, response) {
       window.gtag('event', 'search', {
         search_term: state.searchTerm
       })
       return {
         ...state,
-        results,
+        results: response.value,
+        resultCount: response['@odata.count'],
         currentSearch: state.searchTerm,
         searchTerm: ''
       }
@@ -32,7 +34,7 @@ export default mirror.model({
       return {...state, loading: false}
     },
     clearSearch (state) {
-      return {...state, currentSearch: ''}
+      return {...state, currentSearch: '', resultCount: null}
     }
   },
   effects: {
@@ -52,7 +54,7 @@ export default mirror.model({
         .catch(err => 'An error has occurred: ' + err)
 
       actions.search.stopLoading()
-      actions.search.updateResults(response.value)
+      actions.search.updateResults(response)
     }
   }
 })

--- a/website-react/src/models/SearchModel.js
+++ b/website-react/src/models/SearchModel.js
@@ -22,7 +22,7 @@ export default mirror.model({
       return {
         ...state,
         results: response.value,
-        resultCount: response['@odata.count'],
+        resultCount: response['@odata.count'] ? response['@odata.count'] : 0,
         currentSearch: state.searchTerm,
         searchTerm: ''
       }


### PR DESCRIPTION
Realized the azure search actually returns both the list of results (limited by the query) and the total number of results matching the query. So figured might as well show that.