### PR TITLE
Removed color from the podcast title because when the podcast has the…

### DIFF
--- a/website-react/src/components/Main/Episode/PodcastTitle.js
+++ b/website-react/src/components/Main/Episode/PodcastTitle.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 
 export default styled.b`
-    color: #157169;
     font-size: 0.8rem;
 `


### PR DESCRIPTION
… green background it doesn't have enough contrast.  Removing the color value sets its color to the default text color of #444.  I left the bolding.

Closes #232 and #233 